### PR TITLE
Graham/prerelease polishes

### DIFF
--- a/app/src/main/java/com/kpit/chhotescientists/activity/SessionCheckInActivity.java
+++ b/app/src/main/java/com/kpit/chhotescientists/activity/SessionCheckInActivity.java
@@ -14,7 +14,6 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -27,8 +26,8 @@ import com.kpit.chhotescientists.R;
 import com.kpit.chhotescientists.interfaces.ResultViewContainerReceiver;
 import com.kpit.chhotescientists.model.CheckInQuestion;
 import com.kpit.chhotescientists.model.SessionEvent;
-import com.kpit.chhotescientists.model.result_views.ResultMediaButtonContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultMediaButtonContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 import com.kpit.chhotescientists.util.AppController;
 import com.kpit.chhotescientists.util.ConnectionDetector;
 

--- a/app/src/main/java/com/kpit/chhotescientists/activity/SessionCheckInActivity.java
+++ b/app/src/main/java/com/kpit/chhotescientists/activity/SessionCheckInActivity.java
@@ -96,7 +96,7 @@ public class SessionCheckInActivity extends AppCompatActivity implements ResultV
                     try {
                         // Upload text responses to questions:
                         JSONObject questionsTextJson = assembleTextJson(event);
-                        Log.d("Text Response", questionsTextJson.toString());
+                        Log.d("SessionCheckInActivity", "Text response: " + questionsTextJson.toString());
                         uploadTextResponses(questionsTextJson);
 
                         // Also upload any media if possible

--- a/app/src/main/java/com/kpit/chhotescientists/interfaces/ResultViewContainerReceiver.java
+++ b/app/src/main/java/com/kpit/chhotescientists/interfaces/ResultViewContainerReceiver.java
@@ -1,8 +1,6 @@
 package com.kpit.chhotescientists.interfaces;
 
-import android.widget.ImageView;
-
-import com.kpit.chhotescientists.model.result_views.ResultMediaButtonContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultMediaButtonContainer;
 
 /**
  * An interface used to send views between Question's views and their parent activity.

--- a/app/src/main/java/com/kpit/chhotescientists/model/BooleanQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/BooleanQuestion.java
@@ -1,14 +1,12 @@
 package com.kpit.chhotescientists.model;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Parcel;
-import android.view.View;
 import android.widget.ToggleButton;
 
 import com.kpit.chhotescientists.R;
-import com.kpit.chhotescientists.model.result_views.ResultToggleButtonContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultToggleButtonContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 
 /**
  * See parent CheckInQuestion for documentation.

--- a/app/src/main/java/com/kpit/chhotescientists/model/CheckInQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/CheckInQuestion.java
@@ -4,9 +4,8 @@ import android.app.Activity;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.google.gson.annotations.SerializedName;
 import com.kpit.chhotescientists.interfaces.ResultViewContainerReceiver;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 
 /**
  * A model to be constructed (with GSON) from the server response.

--- a/app/src/main/java/com/kpit/chhotescientists/model/NumberQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/NumberQuestion.java
@@ -1,14 +1,12 @@
 package com.kpit.chhotescientists.model;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Parcel;
 import android.text.InputType;
-import android.view.View;
 import android.widget.EditText;
 
-import com.kpit.chhotescientists.model.result_views.ResultEditTextContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultEditTextContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 
 /**
  * See parent CheckInQuestion for documentation.

--- a/app/src/main/java/com/kpit/chhotescientists/model/PhotoUploadQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/PhotoUploadQuestion.java
@@ -3,15 +3,11 @@ package com.kpit.chhotescientists.model;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Parcel;
-import android.provider.MediaStore;
 import android.view.View;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
 
 import com.kpit.chhotescientists.activity.SessionCheckInActivity;
-import com.kpit.chhotescientists.model.result_views.ResultMediaButtonContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultMediaButtonContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 import com.kpit.chhotescientists.view.MediaButton;
 
 /**

--- a/app/src/main/java/com/kpit/chhotescientists/model/StarRatingQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/StarRatingQuestion.java
@@ -1,13 +1,11 @@
 package com.kpit.chhotescientists.model;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Parcel;
-import android.view.View;
 import android.widget.RatingBar;
 
-import com.kpit.chhotescientists.model.result_views.ResultStarRatingContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultStarRatingContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 
 /**
  * See parent CheckInQuestion for documentation.

--- a/app/src/main/java/com/kpit/chhotescientists/model/TextQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/TextQuestion.java
@@ -1,13 +1,11 @@
 package com.kpit.chhotescientists.model;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Parcel;
-import android.view.View;
 import android.widget.EditText;
 
-import com.kpit.chhotescientists.model.result_views.ResultEditTextContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultEditTextContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 
 /**
  * See parent CheckInQuestion for documentation.

--- a/app/src/main/java/com/kpit/chhotescientists/model/VideoUploadQuestion.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/VideoUploadQuestion.java
@@ -4,13 +4,10 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Parcel;
 import android.view.View;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
 
 import com.kpit.chhotescientists.activity.SessionCheckInActivity;
-import com.kpit.chhotescientists.model.result_views.ResultMediaButtonContainer;
-import com.kpit.chhotescientists.model.result_views.ResultViewContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultMediaButtonContainer;
+import com.kpit.chhotescientists.model.view_containers.ResultViewContainer;
 import com.kpit.chhotescientists.view.MediaButton;
 
 /**

--- a/app/src/main/java/com/kpit/chhotescientists/model/result_views/ResultMediaButtonContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/result_views/ResultMediaButtonContainer.java
@@ -24,7 +24,7 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
 
     private MediaButton mediaButton;
     private String bitmapBase64;
-    Map<String, Bitmap> namedBitmapsMap;
+    Map<String, String> namedBitmapsMap;
 
     public ResultMediaButtonContainer(MediaButton mediaButton) {
         this.mediaButton = mediaButton;
@@ -33,11 +33,7 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
 
     @Override
     public String getResult() {
-        if (bitmapBase64 != null) {
-            return bitmapBase64;
-        } else {
-            return "";
-        }
+        return null;
     }
 
     @Override
@@ -48,8 +44,8 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
     public void addNamedImage(String filename, Bitmap imageBitmap) {
         this.mediaButton.addImageBitmap(imageBitmap);
         this.bitmapBase64 = this.bitmapToBase64(imageBitmap);
-
-        this.namedBitmapsMap.put(filename, imageBitmap);
+        
+        this.namedBitmapsMap.put(filename, bitmapToBase64(imageBitmap));
     }
 
     public void setMediaButtonOnClick(View.OnClickListener onClickListener) {
@@ -87,7 +83,7 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
 
         Set<String> filenameKeys = this.namedBitmapsMap.keySet();
         for (String filename : filenameKeys) {
-            Bitmap bitmap = this.namedBitmapsMap.get(filename);
+            String encodedBitmap = this.namedBitmapsMap.get(filename);
 
             JSONObject dataObject = new JSONObject();
             dataObject.put("event_type_id", eventTypeId);
@@ -96,7 +92,6 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
 
             dataObject.put("media_type", "photo"); // TODO videos...
 
-            String encodedBitmap = bitmapToBase64(bitmap);
             dataObject.put("filebindata", encodedBitmap);
 
             JSONArray dataWrapper = new JSONArray();

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultEditTextContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultEditTextContainer.java
@@ -1,11 +1,7 @@
-package com.kpit.chhotescientists.model.result_views;
+package com.kpit.chhotescientists.model.view_containers;
 
 import android.view.View;
 import android.widget.EditText;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * See parent class ResultViewContainer for documentation.
@@ -19,7 +15,7 @@ public class ResultEditTextContainer extends ResultViewContainer {
     }
 
     @Override
-    public String getResult() {
+    public String getStringResult() {
         return editText.getText().toString();
     }
 

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultMediaButtonContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultMediaButtonContainer.java
@@ -1,4 +1,4 @@
-package com.kpit.chhotescientists.model.result_views;
+package com.kpit.chhotescientists.model.view_containers;
 
 import android.graphics.Bitmap;
 import android.util.Base64;
@@ -23,7 +23,6 @@ import java.util.Set;
 public class ResultMediaButtonContainer extends ResultViewContainer {
 
     private MediaButton mediaButton;
-    private String bitmapBase64;
     Map<String, String> namedBitmapsMap;
 
     public ResultMediaButtonContainer(MediaButton mediaButton) {
@@ -32,8 +31,14 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
     }
 
     @Override
-    public String getResult() {
-        return null;
+    public String getStringResult() {
+        // Don't send actual media data here, just send a yes/no whether it exists.
+        //  Media is sent to a different endpoint.
+        if (namedBitmapsMap != null && namedBitmapsMap.size() > 0) {
+            return "Yes";
+        } else {
+            return "No";
+        }
     }
 
     @Override
@@ -43,8 +48,7 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
 
     public void addNamedImage(String filename, Bitmap imageBitmap) {
         this.mediaButton.addImageBitmap(imageBitmap);
-        this.bitmapBase64 = this.bitmapToBase64(imageBitmap);
-        
+
         this.namedBitmapsMap.put(filename, bitmapToBase64(imageBitmap));
     }
 
@@ -57,24 +61,6 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
         bitmap.compress(Bitmap.CompressFormat.JPEG, 70, byteArrayOutputStream);
         byte[] byteArray = byteArrayOutputStream.toByteArray();
         return Base64.encodeToString(byteArray, Base64.NO_WRAP);
-    }
-
-    @Override
-    public JSONArray addContentsToTextJsonArray(JSONArray dataToSend) throws JSONException {
-        JSONObject viewContentsJson = getBaseJsonDataToSend();
-
-        // Don't send actual media data here, just send a yes/no whether it exists.
-        //  Media is sent to a different endpoint.
-
-        if (bitmapBase64 != null) {
-            viewContentsJson.put("response", "Yes");
-        } else {
-            viewContentsJson.put("response", "No");
-        }
-
-        dataToSend.put(viewContentsJson);
-
-        return dataToSend;
     }
 
     @Override

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultMediaButtonContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultMediaButtonContainer.java
@@ -1,6 +1,8 @@
 package com.kpit.chhotescientists.model.view_containers;
 
+import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.util.Base64;
 import android.view.View;
 
@@ -47,9 +49,22 @@ public class ResultMediaButtonContainer extends ResultViewContainer {
     }
 
     public void addNamedImage(String filename, Bitmap imageBitmap) {
-        this.mediaButton.addImageBitmap(imageBitmap);
-
+        // Encode full-size bitmap and store in the map, keyed by filename.
         this.namedBitmapsMap.put(filename, bitmapToBase64(imageBitmap));
+
+        // Now, resize the bitmap for display (for performance)
+        int rawHeight = imageBitmap.getHeight();
+        int rawWidth = imageBitmap.getWidth();
+
+        // Calculate the scale factor to make the width be 300:
+        float scale = 300f / rawWidth;
+
+        int targetHeight = Math.round(scale * rawHeight);
+        int targetWidth = 300;
+
+        Bitmap scaledBitmap = Bitmap.createScaledBitmap(imageBitmap, targetWidth, targetHeight, false);
+
+        this.mediaButton.addImageBitmap(scaledBitmap);
     }
 
     public void setMediaButtonOnClick(View.OnClickListener onClickListener) {

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultStarRatingContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultStarRatingContainer.java
@@ -1,11 +1,7 @@
-package com.kpit.chhotescientists.model.result_views;
+package com.kpit.chhotescientists.model.view_containers;
 
 import android.view.View;
 import android.widget.RatingBar;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * See parent class ResultViewContainer for documentation.
@@ -19,7 +15,7 @@ public class ResultStarRatingContainer extends ResultViewContainer {
     }
 
     @Override
-    public String getResult() {
+    public String getStringResult() {
         return Integer.toString((int) ratingBar.getRating());
     }
 

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultToggleButtonContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultToggleButtonContainer.java
@@ -1,11 +1,7 @@
-package com.kpit.chhotescientists.model.result_views;
+package com.kpit.chhotescientists.model.view_containers;
 
 import android.view.View;
 import android.widget.ToggleButton;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * See parent class ResultViewContainer for documentation.
@@ -19,7 +15,7 @@ public class ResultToggleButtonContainer extends ResultViewContainer {
     }
 
     @Override
-    public String getResult() {
+    public String getStringResult() {
         return Boolean.toString(toggleButton.isChecked());
     }
 

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultViewContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultViewContainer.java
@@ -1,4 +1,4 @@
-package com.kpit.chhotescientists.model.result_views;
+package com.kpit.chhotescientists.model.view_containers;
 
 import android.view.View;
 
@@ -25,7 +25,7 @@ public abstract class ResultViewContainer {
 
     private CheckInQuestion question;
 
-    public abstract String getResult();
+    public abstract String getStringResult();
 
     public abstract View getView();
 
@@ -38,7 +38,7 @@ public abstract class ResultViewContainer {
      */
     public JSONArray addContentsToTextJsonArray(JSONArray dataToSend) throws JSONException {
         JSONObject viewContentsJson = getBaseJsonDataToSend();
-        viewContentsJson.put("response", getResult());
+        viewContentsJson.put("response", getStringResult());
 
         dataToSend.put(viewContentsJson);
 

--- a/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultViewContainer.java
+++ b/app/src/main/java/com/kpit/chhotescientists/model/view_containers/ResultViewContainer.java
@@ -1,5 +1,6 @@
 package com.kpit.chhotescientists.model.view_containers;
 
+import android.text.TextUtils;
 import android.view.View;
 
 import com.kpit.chhotescientists.model.CheckInQuestion;
@@ -37,10 +38,14 @@ public abstract class ResultViewContainer {
      * @throws JSONException
      */
     public JSONArray addContentsToTextJsonArray(JSONArray dataToSend) throws JSONException {
-        JSONObject viewContentsJson = getBaseJsonDataToSend();
-        viewContentsJson.put("response", getStringResult());
+        String stringResult = getStringResult();
 
-        dataToSend.put(viewContentsJson);
+        // Only send the response if it's not empty / nonzero
+        if (!TextUtils.isEmpty(stringResult) && !stringResult.equals("0")) {
+            JSONObject viewContentsJson = getBaseJsonDataToSend();
+            viewContentsJson.put("response", getStringResult());
+            dataToSend.put(viewContentsJson);
+        }
 
         return dataToSend;
     }


### PR DESCRIPTION
## What's in this PR:
### Performance + design pattern improvements:
- Previously, questionnaire image responses were sent by accessing the `ImageView`s themselves. Now that logic has been separated, so we store the Base64-encoded bitmaps in the model and use those instead.
  - This allows us to reduce the size of the bitmaps that are displayed in the `ImageView`, which greatly improves performance when uploading larger images and reduces incidence of `OutOfMemoryException`. 
- Made the `ResultMediaButtonContainer` class more in line with the other subclasses of  `ResultViewContainer` -- it no longer overrides the `getStringResult` method and instead uses its `result` value to be a "yes"/"no" value for whether the response contains media or not.
### Questionnaire Response Overwriting fix
- Now the data we send to the server will only contain question responses that have been edited. So, an untouched `StarRating` will not be included, nor will a blank `EditText`.
